### PR TITLE
add checks against Game Activity Toggle BD plugin

### DIFF
--- a/src/main/_container.scss
+++ b/src/main/_container.scss
@@ -11,6 +11,10 @@
         left: 4px !important;
         border-radius: 25px;
         background-color: transparent !important;
+        
+        &.gameActivityToggleAdded-Yd-YxC { // game activity toggle BD plugin adds an extra class if enabled; pushes nametag a little further when necessary
+            left: 200px;
+        }
 
         // avatar
         .avatarWrapper-2yR4wp {


### PR DESCRIPTION
Game Activity Toggle plugin on BetterDiscord might extends the button sets, covering the nametag if enabled. The plugin adds an extra class on the app, allows us to push the nametag a little further only if plugin is enabled.

Before:
![image](https://user-images.githubusercontent.com/7719971/124346438-06183c00-dc09-11eb-8aaa-02f422d52b38.png)

After:
![image](https://user-images.githubusercontent.com/7719971/124346425-f4369900-dc08-11eb-930a-07e5dbe0f1b8.png)
